### PR TITLE
add **/datasets in gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 **/model
 **/data
+**/datasets
 **/logs
 
 *.pyc


### PR DESCRIPTION
running the code in `pytorch/tut1_basics/walkthrough.py` generates a `datasets` folder that is not yet ignored by git. several other files will also generate this folder owing to downloading of the fashion mnist dataset. 